### PR TITLE
Stops depending on tree-sitter directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ path = "bindings/rust/lib.rs"
 
 [dependencies]
 tree-sitter-language = "0.1"
+
+[dev-dependencies]
 tree-sitter = "~0.25.5"
 
 [build-dependencies]


### PR DESCRIPTION
Hey!

We don't need to depend on tree-sitter directly.
`tree-sitter-language` is enough, and let us use your crate with other crates that don't share the same version of tree-sitter.

Currently, when I try to update my version of tree-sitter which uses your crate I receive the following error:
```
error: failed to select a version for `tree-sitter`.
    ... required by package `tree-sitter-just v0.2.0`
    ... which satisfies dependency `tree-sitter-just = "^0.2.0"` of package `shared v0.1.0 (/Users/irevoire/ki-editor/shared)`
    ... which satisfies path dependency `shared` (locked to 0.1.0) of package `ki v0.1.0 (/Users/irevoire/ki-editor)`
versions that meet the requirements `~0.25.5` are: 0.25.8, 0.25.10, 0.25.9, 0.25.7, 0.25.6, 0.25.5

package `tree-sitter` links to the native library `tree-sitter`, but it conflicts with a previous package which links to `tree-sitter` as well:
package `tree-sitter v0.26.8`
    ... which satisfies dependency `tree-sitter = "^0.26.8"` of package `ki v0.1.0 (/Users/irevoire/ki-editor)`
Only one package in the dependency graph may specify the same links value. This helps ensure that only one copy of a native library is linked in the final binary. Try to adjust your dependencies so that only one package uses the `links = "tree-sitter"` value. For more information, see https://doc.rust-lang.org/cargo/reference/resolver.html#links.

failed to select a version for `tree-sitter` which could resolve this conflict
```
